### PR TITLE
Add Vercel deployment configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ Thumbs.db
 # Build files (future)
 dist/
 build/
+.vercel

--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,4 @@
+LOCAL_ADMIN_NOTE.md
+Backend/.env
+Backend/node_modules
+.git

--- a/Backend/server.js
+++ b/Backend/server.js
@@ -66,13 +66,14 @@ const ROLE_PERMISSIONS = {
     manageMenuCatalog: false,
   },
 };
+let databaseInitializationPromise = null;
+let lastMaintenanceRunAt = 0;
 
 app.use(cors({
   origin: true,
   credentials: true,
 }));
 app.use(express.json());
-app.use(express.static(ROOT_DIR));
 
 function parseCookies(cookieHeader = "") {
   return cookieHeader.split(";").reduce((cookies, part) => {
@@ -344,6 +345,14 @@ async function initializeDatabase() {
   }
 }
 
+function ensureDatabaseInitialized() {
+  if (!databaseInitializationPromise) {
+    databaseInitializationPromise = initializeDatabase();
+  }
+
+  return databaseInitializationPromise;
+}
+
 async function purgeCompletedOrders() {
   const client = await pool.connect();
 
@@ -383,6 +392,29 @@ async function purgeCompletedOrders() {
     client.release();
   }
 }
+
+async function runMaintenanceIfNeeded() {
+  const now = Date.now();
+
+  if (now - lastMaintenanceRunAt < COMPLETED_ORDER_CLEANUP_INTERVAL_MS) {
+    return;
+  }
+
+  lastMaintenanceRunAt = now;
+  await purgeCompletedOrders();
+}
+
+app.use(async (req, res, next) => {
+  try {
+    await ensureDatabaseInitialized();
+    await runMaintenanceIfNeeded();
+    next();
+  } catch (error) {
+    console.error("Failed to initialize request context:", error);
+    res.status(500).json({ message: "Server initialization failed." });
+  }
+});
+app.use(express.static(ROOT_DIR));
 
 app.get("/", (req, res) => {
   res.sendFile(path.join(ROOT_DIR, "index.html"));
@@ -780,22 +812,26 @@ app.get("/orders/:id", async (req, res) => {
   }
 });
 
-initializeDatabase()
-  .then(() => {
-    purgeCompletedOrders().catch((error) => {
-      console.error("Initial completed-order purge failed:", error);
-    });
-    setInterval(() => {
+if (require.main === module) {
+  ensureDatabaseInitialized()
+    .then(() => {
       purgeCompletedOrders().catch((error) => {
-        console.error("Scheduled completed-order purge failed:", error);
+        console.error("Initial completed-order purge failed:", error);
       });
-    }, COMPLETED_ORDER_CLEANUP_INTERVAL_MS);
+      setInterval(() => {
+        purgeCompletedOrders().catch((error) => {
+          console.error("Scheduled completed-order purge failed:", error);
+        });
+      }, COMPLETED_ORDER_CLEANUP_INTERVAL_MS);
 
-    app.listen(PORT, () => {
-      console.log(`Server running on port ${PORT}`);
+      app.listen(PORT, () => {
+        console.log(`Server running on port ${PORT}`);
+      });
+    })
+    .catch((error) => {
+      console.error("Failed to initialize database:", error);
+      process.exit(1);
     });
-  })
-  .catch((error) => {
-    console.error("Failed to initialize database:", error);
-    process.exit(1);
-  });
+}
+
+module.exports = app;

--- a/api/index.js
+++ b/api/index.js
@@ -1,0 +1,3 @@
+const app = require("../Backend/server");
+
+module.exports = app;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "restaurant-website",
+  "version": "1.0.0",
+  "private": true,
+  "type": "commonjs",
+  "dependencies": {
+    "cors": "^2.8.6",
+    "dotenv": "^17.3.1",
+    "express": "^5.2.1",
+    "pg": "^8.20.0"
+  }
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,29 @@
+{
+  "cleanUrls": true,
+  "rewrites": [
+    {
+      "source": "/admin-login",
+      "destination": "/admin-login.html"
+    },
+    {
+      "source": "/admin",
+      "destination": "/admin.html"
+    },
+    {
+      "source": "/menu",
+      "destination": "/api/index"
+    },
+    {
+      "source": "/orders",
+      "destination": "/api/index"
+    },
+    {
+      "source": "/orders/(.*)",
+      "destination": "/api/index"
+    },
+    {
+      "source": "/admin/(.*)",
+      "destination": "/api/index"
+    }
+  ]
+}


### PR DESCRIPTION
## What changed
- add Vercel deployment configuration files at the repo root
- make the Express server exportable for Vercel serverless usage
- add a Vercel ignore file so local-only notes and backend env files are not uploaded
- keep `main` as the long-term production branch while `Dev1.1` continues to serve preview work

## Why
The app was already deployed manually, but the repo itself did not yet contain the Vercel setup needed for repeatable deployments from Git. This PR moves that deployment wiring into source control so future production deploys can come from `main`.

## Validation
- `node --check Backend/server.js`
- `node --check api/index.js`
- `npx vercel deploy`
- `npx vercel deploy --prod`