### PR TITLE
Keep completed orders in dashboard history

### DIFF
--- a/Backend/server.js
+++ b/Backend/server.js
@@ -12,8 +12,6 @@ const ROOT_DIR = path.join(__dirname, "..");
 const PORT = Number(process.env.PORT || 3000);
 const ADMIN_SESSION_COOKIE = "admin_session";
 const SESSION_DURATION_MS = 1000 * 60 * 60 * 8;
-const COMPLETED_ORDER_RETENTION_SECONDS = 30;
-const COMPLETED_ORDER_CLEANUP_INTERVAL_MS = 5 * 1000;
 const VALID_ORDER_STATUSES = ["Pending", "Preparing", "Ready", "Completed"];
 const VALID_USER_ROLES = ["admin", "staff", "chef"];
 const VALID_MENU_CATEGORIES = ["main-course", "snack", "beverages", "dessert"];
@@ -159,7 +157,6 @@ const ROLE_PERMISSIONS = {
   },
 };
 let databaseInitializationPromise = null;
-let lastMaintenanceRunAt = 0;
 const rateLimitState = new Map();
 
 app.set("trust proxy", true);
@@ -548,11 +545,8 @@ async function initializeDatabase() {
 
   await pool.query(
     `UPDATE orders
-     SET completed_expires_at = completed_at + ($1 * INTERVAL '1 second')
-     WHERE status = 'Completed'
-       AND completed_at IS NOT NULL
-       AND completed_expires_at IS NULL`,
-    [COMPLETED_ORDER_RETENTION_SECONDS]
+     SET completed_expires_at = NULL
+     WHERE completed_expires_at IS NOT NULL`
   );
 
   await pool.query(`
@@ -590,60 +584,9 @@ function ensureDatabaseInitialized() {
   return databaseInitializationPromise;
 }
 
-async function purgeCompletedOrders() {
-  const client = await pool.connect();
-
-  try {
-    await client.query("BEGIN");
-    const expiredOrdersResult = await client.query(
-      `SELECT order_id
-       FROM orders
-       WHERE status = 'Completed'
-         AND completed_expires_at IS NOT NULL
-         AND completed_expires_at <= NOW()`
-    );
-
-    const expiredOrderIds = expiredOrdersResult.rows.map((row) => row.order_id);
-
-    if (expiredOrderIds.length > 0) {
-      await client.query(
-        "DELETE FROM order_status_history WHERE order_id = ANY($1::text[])",
-        [expiredOrderIds]
-      );
-      await client.query(
-        "DELETE FROM orders WHERE order_id = ANY($1::text[])",
-        [expiredOrderIds]
-      );
-    }
-
-    await client.query("COMMIT");
-
-    if (expiredOrderIds.length > 0) {
-      console.log(`Purged ${expiredOrderIds.length} completed order(s) after ${COMPLETED_ORDER_RETENTION_SECONDS} seconds.`);
-    }
-  } catch (error) {
-    await client.query("ROLLBACK");
-    console.error("Failed to purge completed orders:", error);
-  } finally {
-    client.release();
-  }
-}
-
-async function runMaintenanceIfNeeded() {
-  const now = Date.now();
-
-  if (now - lastMaintenanceRunAt < COMPLETED_ORDER_CLEANUP_INTERVAL_MS) {
-    return;
-  }
-
-  lastMaintenanceRunAt = now;
-  await purgeCompletedOrders();
-}
-
 app.use(async (req, res, next) => {
   try {
     await ensureDatabaseInitialized();
-    await runMaintenanceIfNeeded();
     next();
   } catch (error) {
     console.error("Failed to initialize request context:", error);
@@ -1080,14 +1023,10 @@ app.patch("/admin/orders/:id/status", requireAdminAuth, requirePermission("updat
              WHEN $1 = 'Completed' AND status = 'Completed' THEN COALESCE(completed_at, NOW())
              ELSE NULL
            END,
-           completed_expires_at = CASE
-             WHEN $1 = 'Completed' AND status <> 'Completed' THEN NOW() + ($3 * INTERVAL '1 second')
-             WHEN $1 = 'Completed' AND status = 'Completed' THEN COALESCE(completed_expires_at, NOW() + ($3 * INTERVAL '1 second'))
-             ELSE NULL
-           END
+           completed_expires_at = NULL
        WHERE order_id = $2
        RETURNING *`,
-      [status, orderId, COMPLETED_ORDER_RETENTION_SECONDS]
+      [status, orderId]
     );
 
     await pool.query(
@@ -1195,15 +1134,6 @@ app.get("/orders/:id", createRateLimiter("orderLookup"), async (req, res) => {
 if (require.main === module) {
   ensureDatabaseInitialized()
     .then(() => {
-      purgeCompletedOrders().catch((error) => {
-        console.error("Initial completed-order purge failed:", error);
-      });
-      setInterval(() => {
-        purgeCompletedOrders().catch((error) => {
-          console.error("Scheduled completed-order purge failed:", error);
-        });
-      }, COMPLETED_ORDER_CLEANUP_INTERVAL_MS);
-
       app.listen(PORT, () => {
         console.log(`Server running on port ${PORT}`);
       });

--- a/JS/admin.js
+++ b/JS/admin.js
@@ -3,6 +3,9 @@ const ORDER_STATUSES = ["Pending", "Preparing", "Ready", "Completed"];
 const adminGreeting = document.getElementById("adminGreeting");
 const dashboardMessage = document.getElementById("dashboardMessage");
 const adminOrdersList = document.getElementById("adminOrdersList");
+const orderViewTabs = document.getElementById("orderViewTabs");
+const orderStatusFilters = document.getElementById("orderStatusFilters");
+const orderPanelDescription = document.getElementById("orderPanelDescription");
 const themeToggleBtn = document.getElementById("themeToggleBtn");
 const refreshOrdersBtn = document.getElementById("refreshOrdersBtn");
 const logoutBtn = document.getElementById("logoutBtn");
@@ -25,7 +28,8 @@ const adminPanels = Array.from(document.querySelectorAll("[data-admin-panel]"));
 const statTotalOrders = document.getElementById("statTotalOrders");
 const statPendingOrders = document.getElementById("statPendingOrders");
 const statPreparingOrders = document.getElementById("statPreparingOrders");
-const statClosedOrders = document.getElementById("statClosedOrders");
+const statReadyOrders = document.getElementById("statReadyOrders");
+const statCompletedOrders = document.getElementById("statCompletedOrders");
 const THEME_STORAGE_KEY = "admin-theme-preference";
 const MENU_CATEGORIES = [
   { value: "main-course", label: "Main Course" },
@@ -37,6 +41,9 @@ const MENU_CATEGORIES = [
 let currentSession = null;
 let activeAdminPanel = "overview";
 let activeTheme = "light";
+let allOrders = [];
+let activeOrderView = "active";
+let activeOrderFilter = "all";
 
 function getInitialTheme() {
   const savedTheme = window.localStorage.getItem(THEME_STORAGE_KEY);
@@ -117,12 +124,109 @@ function getStatusPill(status) {
 function updateStats(orders) {
   const pending = orders.filter((order) => order.status === "Pending").length;
   const preparing = orders.filter((order) => order.status === "Preparing").length;
-  const readyOrCompleted = orders.filter((order) => ["Ready", "Completed"].includes(order.status)).length;
+  const ready = orders.filter((order) => order.status === "Ready").length;
+  const completed = orders.filter((order) => order.status === "Completed").length;
 
   statTotalOrders.textContent = String(orders.length);
   statPendingOrders.textContent = String(pending);
   statPreparingOrders.textContent = String(preparing);
-  statClosedOrders.textContent = String(readyOrCompleted);
+  statReadyOrders.textContent = String(ready);
+  statCompletedOrders.textContent = String(completed);
+}
+
+function formatDateTime(value) {
+  if (!value) {
+    return "Not recorded";
+  }
+
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return "Not recorded";
+  }
+
+  return parsed.toLocaleString("id-ID", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function getOrderTimestamp(order, keys) {
+  for (const key of keys) {
+    const rawValue = order[key];
+    if (!rawValue) {
+      continue;
+    }
+
+    const parsed = new Date(rawValue);
+    if (!Number.isNaN(parsed.getTime())) {
+      return parsed.getTime();
+    }
+  }
+
+  return 0;
+}
+
+function setOrderViewTabStyles() {
+  Array.from(orderViewTabs.querySelectorAll("[data-order-view]")).forEach((button) => {
+    const isActive = button.dataset.orderView === activeOrderView;
+    button.classList.toggle("bg-slate-900", isActive);
+    button.classList.toggle("text-white", isActive);
+    button.classList.toggle("hover:bg-slate-800", isActive);
+    button.classList.toggle("border", !isActive);
+    button.classList.toggle("border-slate-300", !isActive);
+    button.classList.toggle("text-slate-700", !isActive);
+    button.classList.toggle("hover:bg-slate-50", !isActive);
+  });
+}
+
+function setOrderFilterStyles() {
+  Array.from(orderStatusFilters.querySelectorAll("[data-order-filter]")).forEach((button) => {
+    const isActive = button.dataset.orderFilter === activeOrderFilter;
+    button.classList.toggle("bg-orange-500", isActive);
+    button.classList.toggle("text-white", isActive);
+    button.classList.toggle("hover:bg-orange-600", isActive);
+    button.classList.toggle("border", !isActive);
+    button.classList.toggle("border-slate-300", !isActive);
+    button.classList.toggle("text-slate-600", !isActive);
+    button.classList.toggle("hover:bg-slate-50", !isActive);
+  });
+}
+
+function getVisibleOrders() {
+  const completedOrders = allOrders
+    .filter((order) => order.status === "Completed")
+    .sort((left, right) => getOrderTimestamp(right, ["completedAt", "completed_at", "createdAt", "created_at"]) - getOrderTimestamp(left, ["completedAt", "completed_at", "createdAt", "created_at"]));
+
+  if (activeOrderView === "completed") {
+    return completedOrders;
+  }
+
+  const activeOrders = allOrders
+    .filter((order) => order.status !== "Completed")
+    .sort((left, right) => getOrderTimestamp(left, ["createdAt", "created_at", "completedAt", "completed_at"]) - getOrderTimestamp(right, ["createdAt", "created_at", "completedAt", "completed_at"]));
+
+  switch (activeOrderFilter) {
+    case "Pending":
+    case "Preparing":
+    case "Ready":
+      return activeOrders.filter((order) => order.status === activeOrderFilter);
+    case "followup":
+      return activeOrders.filter((order) => order.requires_staff_followup || order.requiresStaffFollowup);
+    default:
+      return activeOrders;
+  }
+}
+
+function updateOrderPanelState() {
+  orderPanelDescription.textContent = activeOrderView === "completed"
+    ? "Review completed orders here. If one was completed by mistake, you can still move it back into the active queue."
+    : "Track the live queue, filter by status, and update orders as they move through service.";
+  orderStatusFilters.classList.toggle("hidden", activeOrderView === "completed");
+  setOrderViewTabStyles();
+  setOrderFilterStyles();
 }
 
 function setActiveAdminPanel(panelName) {
@@ -179,7 +283,9 @@ function renderOrders(orders) {
   if (orders.length === 0) {
     adminOrdersList.innerHTML = `
       <div class="admin-empty-state rounded-2xl border border-dashed border-slate-300 bg-slate-50 p-8 text-center text-slate-500">
-        No orders yet. Customer orders will appear here once they are submitted.
+        ${activeOrderView === "completed"
+          ? "No completed orders yet. Finished orders will appear here once they are marked completed."
+          : "No active orders right now. New customer orders will appear here once they are submitted."}
       </div>
     `;
     return;
@@ -226,7 +332,7 @@ function renderOrders(orders) {
             </div>
             ${order.status === "Completed" ? `
               <p class="mt-2 text-xs text-slate-400">
-                The 30-second removal timer starts when this order is marked completed.
+                Completed at ${formatDateTime(order.completedAt)}.
               </p>
             ` : ""}
           </div>
@@ -393,9 +499,11 @@ async function loadOrders() {
   }
 
   const orders = await readJsonResponse(response);
+  allOrders = Array.isArray(orders) ? orders : [];
   updateStats(orders);
-  renderOrders(orders);
-  return orders;
+  updateOrderPanelState();
+  renderOrders(getVisibleOrders());
+  return allOrders;
 }
 
 async function loadMenuManagement() {
@@ -488,6 +596,28 @@ adminOrdersList.addEventListener("click", async (event) => {
     event.target.disabled = false;
     event.target.textContent = originalText;
   }
+});
+
+orderViewTabs.addEventListener("click", (event) => {
+  const button = event.target.closest("[data-order-view]");
+  if (!button) {
+    return;
+  }
+
+  activeOrderView = button.dataset.orderView;
+  updateOrderPanelState();
+  renderOrders(getVisibleOrders());
+});
+
+orderStatusFilters.addEventListener("click", (event) => {
+  const button = event.target.closest("[data-order-filter]");
+  if (!button) {
+    return;
+  }
+
+  activeOrderFilter = button.dataset.orderFilter;
+  updateOrderPanelState();
+  renderOrders(getVisibleOrders());
 });
 
 menuManagementList.addEventListener("click", async (event) => {

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ A full-stack restaurant ordering app with a customer-facing menu and a separate 
 - Add-menu flow uses a modal with a blurred backdrop instead of an always-open form
 - Large or detailed orders show a staff-follow-up notice after submission and inside the dashboard
 - Admin-only user management for staff dashboard accounts
-- Completed orders are automatically deleted after about 30 seconds for testing
+- Order management now separates the active queue from completed-order history
+- Completed orders remain available in the dashboard and can still be moved back to the active queue if they were completed by mistake
 - Basic anti-spam protection is enabled for admin login, order submission, and order lookup requests
 
 ### Data
@@ -175,7 +176,7 @@ npm run create:admin -- admin StrongPassword123 "Restaurant Admin"
 - `GET /admin/orders/:id/history`
 - `GET /admin/menu`
 - `POST /admin/menu`
-- `PATCH /admin/menu/:id/price`
+- `PATCH /admin/menu/:id`
 - `PATCH /admin/menu/:id/availability`
 - `GET /admin/users`
 - `POST /admin/users`
@@ -197,6 +198,7 @@ npm run create:admin -- admin StrongPassword123 "Restaurant Admin"
 - Menu images are referenced by asset path strings stored in the database
 - New menu items currently use an image path or URL instead of file upload storage
 - Menu categories are intentionally grouped into broader labels such as `Main Course`, `Snack`, `Beverages`, and `Dessert`
-- Completed orders are auto-purged after about 30 seconds only for testing and should be adjusted before production
+- Completed orders are retained in the database and reviewed from a dedicated completed-history view in the staff dashboard
+- The customer page includes stable automation-friendly selectors for external browser tests
 - The repository now contains Vercel deployment configuration at the repo root
 - `main` should be used for releases, while `Dev1.1` should be used for preview/testing work

--- a/admin.html
+++ b/admin.html
@@ -202,8 +202,12 @@
               <p id="statPreparingOrders" class="mt-3 text-3xl font-black text-orange-600">0</p>
             </article>
             <article class="admin-card rounded-2xl bg-white p-5 shadow-sm ring-1 ring-green-200">
-              <p class="text-sm font-semibold uppercase tracking-wide text-green-600">Ready / Completed</p>
-              <p id="statClosedOrders" class="mt-3 text-3xl font-black text-green-600">0</p>
+              <p class="text-sm font-semibold uppercase tracking-wide text-green-600">Ready</p>
+              <p id="statReadyOrders" class="mt-3 text-3xl font-black text-green-600">0</p>
+            </article>
+            <article class="admin-card rounded-2xl bg-white p-5 shadow-sm ring-1 ring-slate-300">
+              <p class="text-sm font-semibold uppercase tracking-wide text-slate-600">Completed</p>
+              <p id="statCompletedOrders" class="mt-3 text-3xl font-black text-slate-700">0</p>
             </article>
           </div>
 
@@ -246,8 +250,37 @@
 
         <section id="adminPanelOrders" data-admin-panel="orders" class="admin-card hidden rounded-3xl bg-white p-6 shadow-sm ring-1 ring-slate-200">
           <div class="border-b border-slate-200 pb-5">
-            <h2 class="text-2xl font-bold">Incoming Orders</h2>
-            <p class="mt-1 text-sm text-slate-500">Update the status here so customers see the latest progress on the public page. Completed orders will auto-delete after 30 seconds for testing.</p>
+            <h2 class="text-2xl font-bold">Order Management</h2>
+            <p id="orderPanelDescription" class="mt-1 text-sm text-slate-500">Track the active queue, move orders through service statuses, and review completed orders in a separate history view.</p>
+          </div>
+
+          <div class="mt-6 flex flex-col gap-4 xl:flex-row xl:items-center xl:justify-between">
+            <div id="orderViewTabs" class="flex flex-wrap gap-3">
+              <button data-order-view="active" class="rounded-xl bg-slate-900 px-4 py-2 text-sm font-semibold text-white transition hover:bg-slate-800">
+                Active Queue
+              </button>
+              <button data-order-view="completed" class="rounded-xl border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-700 transition hover:bg-slate-50">
+                Completed History
+              </button>
+            </div>
+
+            <div id="orderStatusFilters" class="flex flex-wrap gap-2">
+              <button data-order-filter="all" class="rounded-full bg-orange-500 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-white transition hover:bg-orange-600">
+                All Active
+              </button>
+              <button data-order-filter="Pending" class="rounded-full border border-slate-300 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-slate-600 transition hover:bg-slate-50">
+                Pending
+              </button>
+              <button data-order-filter="Preparing" class="rounded-full border border-slate-300 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-slate-600 transition hover:bg-slate-50">
+                Preparing
+              </button>
+              <button data-order-filter="Ready" class="rounded-full border border-slate-300 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-slate-600 transition hover:bg-slate-50">
+                Ready
+              </button>
+              <button data-order-filter="followup" class="rounded-full border border-slate-300 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-slate-600 transition hover:bg-slate-50">
+                Needs Follow-Up
+              </button>
+            </div>
           </div>
 
           <div id="adminOrdersList" class="mt-6 grid gap-4"></div>


### PR DESCRIPTION
## Summary
- keep completed orders in dashboard history instead of auto-deleting them
- split admin order management into active queue and completed history views
- update overview stats and docs to match the new workflow

## Testing
- node --check Backend/server.js
- node --check JS/admin.js